### PR TITLE
Add description to package.yaml

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,25 @@ category:            Dependent Types
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
 # common to point users to the README.md file.
-description:         Please see the README on GitHub at <https://github.com/mstksg/decidable#readme>
+#
+# Which is a bad practice.
+#
+# - Users of Hackage see a link to see readme somewhere,
+#   even Hackage nicely renders the (inter-page) link to README right below.
+# - Hackage and Stackage both display README on the package pages.
+# - Actually, if a README is only four lines, why you need it at all?
+#     - GitHub's readme can point to "look at .cabal or package.yaml" file instead.
+#     - Or the readme could contain more general documentation, examples etc,
+#       and description in the .cabal is then an "abstract" of it.
+#
+# So we don't avoid duplicated efforts, but rather provide as good user
+# experience to all possible users of your package.
+#
+description: |
+  This library provides combinators and typeclasses for working and manipulating
+  type-level predicates in Haskell, which are represented as matchable type-level
+  functions @k ~> Type@ from the @singletons@ library.  See "Data.Type.Predicate"
+  for a good starting point.
 
 ghc-options:
 - -Wall


### PR DESCRIPTION
## Hackage looks stupid

![screenshot from 2018-10-14 01-44-20](https://user-images.githubusercontent.com/51087/46910800-c5a59b00-cf53-11e8-8357-249b5a187e35.png)

## There is a readme:

![screenshot from 2018-10-14 01-44-37](https://user-images.githubusercontent.com/51087/46910799-c5a59b00-cf53-11e8-9b95-1818a6e5184a.png)

## Local haddock looks like

(and Hackage could look like that modulo new theme used)

![screenshot from 2018-10-14 01-50-57](https://user-images.githubusercontent.com/51087/46910798-c5a59b00-cf53-11e8-8496-fc4b70f294e1.png)

---

Personally the "see README.md" is quite turn-off when considering whether to use a package.

---

Stack's package template is crap.

---

P.S. QuantifiedConstraints is only GHC-8.6. I recommend adding `other-extensions: QuantifiedConstraints` (and other extensions) to *declare* what features of GHC your package uses.
